### PR TITLE
Add component filters to styleguide

### DIFF
--- a/tests/dummy/app/controllers/styleguide.js
+++ b/tests/dummy/app/controllers/styleguide.js
@@ -1,61 +1,33 @@
-/* globals requirejs */
 import Ember from 'ember';
 
-const COMPONENT_BLACKLIST = [
-  'ui-component',
-  'ui-demo',
-  'ui-dropbutton-trigger',
-  'ui-icon',
-  'ui-input',
-  'ui-field',
-  'ui-kind',
-  'ui-loading',
-  'ui-modal',
-  'ui-modal-backdrop',
-  'ui-panel-content',
-  'ui-panel-titlebar',
-  'ui-popup',
-  'ui-prevent-scroll-outside',
-  'ui-ripple',
-  'ui-ripple-animation',
-  'ui-table-cell',
-  'ui-table-layout',
-  'ui-table-row'
-];
-
-let uiComponentModules = Object.keys(requirejs.entries)
-  .filter((module) => /^ui-base-theme\/components\/ui-/.test(module));
-
-let uiComponentNames = uiComponentModules
-  .map(m => m.replace(/^ui-base-theme\/components\//, ''))
-  .filter(m => !/--/.test(m));
-
-let componentCustomizations = {
-  'ui-button': {
-    kinds: ['default', 'material', 'primary', 'simple'],
-    states: ['active', 'disabled', 'focus', 'loading']
-  },
-  'ui-checkbox': {
-    states: ['disabled', 'error']
-  },
-  'ui-textarea': {
-    states: ['disabled', 'error']
-  }
-};
-
-Ember.A(uiComponentNames).removeObjects(COMPONENT_BLACKLIST);
-
-let allComponents = uiComponentNames.map((componentName) => {
-  let attrs = { name: componentName, kinds: ['default'], states: [] };
-  let customizations = componentCustomizations[componentName];
-
-  if (customizations) {
-    return Object.assign(attrs, customizations);
-  } else {
-    return attrs;
-  }
-});
-
 export default Ember.Controller.extend({
-  allComponents
+  queryParams: ['filter'],
+
+  filter: [],
+
+  filteredComponents: Ember.computed('filter.[]', 'model.theme.components.[]', function() {
+    let components = this.get('model.theme.components');
+    let filter = this.get('filter');
+
+    if (filter.length > 0) {
+      return components.filter((component) => filter.indexOf(component.name) > -1);
+    } else {
+      return components;
+    }
+  }),
+
+  actions: {
+    toggleComponentFilter(componentName) {
+      let filter = this.get('filter');
+      let newFilter = [].concat(filter);
+      let indexOfComponentName = newFilter.indexOf(componentName);
+
+      if (indexOfComponentName > -1) {
+        newFilter.splice(indexOfComponentName, 1)
+        this.set('filter', newFilter);
+      } else {
+        this.set('filter', newFilter.concat(componentName));
+      }
+    }
+  }
 });

--- a/tests/dummy/app/routes/styleguide.js
+++ b/tests/dummy/app/routes/styleguide.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  ajax: Ember.inject.service(),
+
+  model() {
+    return Ember.RSVP.hash({
+      theme: this.get('ajax').request('/__ui/themes').then((data) => {
+        return data[0];
+      })
+    });
+  }
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,5 +1,5 @@
 body {
-  padding: 10px;
+  margin: 0;
   background: #f5f8f9;
 }
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,5 @@
-{{outlet}}
+<screen>
+  <page>
+    {{outlet}}
+  </page>
+</screen>

--- a/tests/dummy/app/templates/styleguide.hbs
+++ b/tests/dummy/app/templates/styleguide.hbs
@@ -1,5 +1,37 @@
-<h1>Styleguide</h1>
+<box fit>
+  <h1>Styleguide</h1>
+</box>
+<hbox>
+  <box sm="3">
+    {{#ui-panel as |p|}}
+      {{#p.titlebar}}
+        Components
+      {{/p.titlebar}}
 
-{{#each allComponents as |demoComponent|}}
-  {{ui-demo demoComponent=demoComponent}}
-{{/each}}
+      {{#p.content}}
+        {{#each model.theme.components as |component|}}
+          {{#if component.demoFile}}
+            <div>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={{contains component.name filter}}
+                  onchange={{action "toggleComponentFilter" component.name}}
+                />
+                {{component.name}}
+              </label>
+            </div>
+          {{/if}}
+        {{/each}}
+      {{/p.content}}
+    {{/ui-panel}}
+  </box>
+
+  <box sm="9">
+    {{#each filteredComponents as |component|}}
+      {{#if component.demoFile}}
+        {{ui-demo demoComponent=component}}
+      {{/if}}
+    {{/each}}
+  </box>
+</hbox>


### PR DESCRIPTION
**This requires changes to untitled-ui that aren't in yet and would cause this to break the styleguide.**

There are also weird performance issues that need to be looked at as well as errors that are pretty easy to produce by clicking on the filters very quickly. The error is related to the `updateContainerSize()` function in the `ui-table` trying to set properties after the component has been destroyed.
#### Preview

![](http://g.recordit.co/19tAklCWLx.gif)
