### PR TITLE
Remove manual component class prefixing

### DIFF
--- a/addon/styles/components/base--ui-pagination---pages--default.scss
+++ b/addon/styles/components/base--ui-pagination---pages--default.scss
@@ -17,7 +17,7 @@
   justify-content: center;
   font-family: $font;
 
-  &---page {
+  &--page {
     display: block;
     padding: $padding;
     margin: $margin;

--- a/addon/templates/components/base--ui-checkbox--default.hbs
+++ b/addon/templates/components/base--ui-checkbox--default.hbs
@@ -4,7 +4,7 @@
   class="{{ui-state states 'disabled' 'enabled' 'checked' 'error'}}"
 >
   {{input
-    class=(concat uiPrefix "--input")
+    class="input"
     type="checkbox"
     checked=value
     focusIn=action.onFocusIn

--- a/addon/templates/components/base--ui-dropbutton---trigger--default.hbs
+++ b/addon/templates/components/base--ui-dropbutton---trigger--default.hbs
@@ -13,8 +13,9 @@
       active=states.active}}
         {{ui-icon
           icon="dropbutton"
-          class=(concat uiPrefix "--icon "
-                        (ui-state states 'disabled' el=(concat uiPrefix '--icon')))
+          class=(concat "icon "
+            (ui-state states "disabled" el="icon")
+          )
         }}
     {{/group.button}}
   {{/ui-button-group}}
@@ -30,8 +31,9 @@
       {{yield}}
       {{ui-icon
         icon="dropbutton"
-        class=(concat uiPrefix "--icon "
-                      (ui-state states 'disabled' el=(concat uiPrefix '--icon')))
+        class=(concat "icon "
+          (ui-state states "disabled" el="icon")
+        )
       }}
   {{/ui-button}}
 {{/if}}

--- a/addon/templates/components/base--ui-input--default.hbs
+++ b/addon/templates/components/base--ui-input--default.hbs
@@ -9,8 +9,10 @@
       focusOut=onFocusOut
       value=value
       aria-labelledby=ids.label
-      class=(concat uiPrefix "--input "
-                    (ui-state states 'disabled' 'error' el=(concat uiPrefix '--input')))}}
+      class=(concat "input "
+        (ui-state states "disabled" "error" el="input")
+      )
+    }}
   </div>
 </div>
 

--- a/addon/templates/components/base--ui-pagination---pages--default.hbs
+++ b/addon/templates/components/base--ui-pagination---pages--default.hbs
@@ -1,5 +1,5 @@
 <div {{ui-root}}>
   {{yield (hash
-    page=(component "link-to" class=(concat uiPrefix "---page")))
+    page=(component "link-to" class="page"))
   }}
 </div>

--- a/addon/templates/components/base--ui-select--default.hbs
+++ b/addon/templates/components/base--ui-select--default.hbs
@@ -1,8 +1,9 @@
 <div {{ui-root}}>
   <div class="wrapper">
     {{#x-select
-      class=(concat uiPrefix "--select "
-            (ui-state states 'disabled' 'error' el=(concat uiPrefix '--select')))
+      class=(concat "select "
+        (ui-state states "disabled" "error" el="select")
+      )
       disabled=states.disabled
       focusIn=onFocusIn
       focusOut=onFocusOut

--- a/addon/templates/components/base--ui-tabs--default.hbs
+++ b/addon/templates/components/base--ui-tabs--default.hbs
@@ -1,7 +1,5 @@
 <div {{ui-root}}>
   {{yield (hash
-    link-to=(component "link-to"
-      class=(concat uiPrefix "--tab" " " uiPrefix "--tab--link")
-    )
+    link-to=(component "link-to" class="tab tab--link")
   )}}
 </div>

--- a/addon/templates/components/base--ui-textarea--default.hbs
+++ b/addon/templates/components/base--ui-textarea--default.hbs
@@ -8,8 +8,9 @@
       focusOut=onFocusOut
       value=value
       aria-labelledby=ids.label
-      class=(concat uiPrefix "--input "
-                    (ui-state states 'disabled' 'error' el=(concat uiPrefix '--input')))
+      class=(concat "input "
+        (ui-state states "disabled" "error" el="input")
+      )
       rows=rows}}
   </div>
 </div>


### PR DESCRIPTION
No longer needed as of
https://github.com/prototypal-io/untitled-ui/pull/108
